### PR TITLE
chore: prereleases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - "pre*"
+      - prerelease
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - "pre*"
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
Only the zazuko bot can release this package. I wanted to release a pre from local machine but maybe instead we can have the changesets action do it instead on branches whose name starts with `pre`

To be honest I'm not sure what this PR will do. We might get two of those release PRs. Let's see :)